### PR TITLE
Fix scoring of search results (somewhat)

### DIFF
--- a/projects/mtd/src/app/pages/search/search/search.component.ts
+++ b/projects/mtd/src/app/pages/search/search/search.component.ts
@@ -167,7 +167,7 @@ export class SearchComponent implements OnDestroy, OnInit {
       // Collect l1Exact matches and add to allMatches
       const populateL1Exact = () => {
         for (const result of l1Exact) {
-          const entry = result;
+          const entry = Object.assign({}, result);
           entry.type = 'L1';
           entry.distance = this.matchThreshold;
           allMatches.push(entry);
@@ -177,7 +177,7 @@ export class SearchComponent implements OnDestroy, OnInit {
       // Collect l2Exact matches and add to allMatches
       const populateL2Exact = () => {
         for (const result of l2Exact) {
-          const entry = result;
+          const entry = Object.assign({}, result);
           entry.type = 'L2';
           entry.distance = this.matchThreshold;
           allMatches.push(entry);
@@ -187,7 +187,7 @@ export class SearchComponent implements OnDestroy, OnInit {
       // Collect l1Partial matches and add to allMatches
       const populateL1Partial = () => {
         for (const result of l1Partial.concat(l1PartialSlug)) {
-          const entry = result;
+          const entry = Object.assign({}, result);
           entry.type = 'L1';
           entry.distance = this.partialThreshold;
           allMatches.push(entry);
@@ -197,7 +197,7 @@ export class SearchComponent implements OnDestroy, OnInit {
       // Collect l2Partial matches and add to allMatches
       const populateL2Partial = () => {
         for (const result of l2Partial) {
-          const entry = result;
+          const entry = Object.assign({}, result);
           entry.type = 'L2';
           entry.distance = this.partialThreshold;
           allMatches.push(entry);
@@ -206,8 +206,9 @@ export class SearchComponent implements OnDestroy, OnInit {
 
       const populateTarget = () => {
         for (const result of target) {
-          const entry = result[1];
+          const entry = Object.assign({}, result[1]);
           entry.type = 'L1';
+          entry.distance += this.approxWeight;
           const resultIndex = allMatches.findIndex(
             match =>
               match.word === entry.word && match.definition === match.definition
@@ -217,9 +218,9 @@ export class SearchComponent implements OnDestroy, OnInit {
           } else {
             if (
               'distance' in allMatches[resultIndex] &&
-              allMatches[resultIndex].distance > result[0]
+              allMatches[resultIndex].distance > entry.distance
             ) {
-              allMatches[resultIndex].distance = result[0] + this.approxWeight;
+              allMatches[resultIndex].distance = entry.distance;
             }
           }
         }

--- a/projects/mtd/src/assets/js/deadSearch.js
+++ b/projects/mtd/src/assets/js/deadSearch.js
@@ -21,9 +21,9 @@ var l1SearchAlg = null;
 var l1SearchAlgWord = null;
 
 function searchL1(query_value) {
-  if (l1SearchAlg === null || l1SearchAlgWord) {
-    l1SearchAlg = distanceCalculator(getAllEntries());
-    l1SearchAlgWord = distanceCalculatorWord(getAllEntries());
+  if (l1SearchAlg === null || l1SearchAlgWord === null) {
+    l1SearchAlg = distanceCalculator(getAllEntries(), 'compare_form');
+    l1SearchAlgWord = distanceCalculator(getAllEntries(), 'word');
   }
   query_value = query_value.toLowerCase();
   // Case for multi-word query

--- a/projects/mtd/src/assets/js/editDistance.js
+++ b/projects/mtd/src/assets/js/editDistance.js
@@ -15,76 +15,18 @@
 //        along with this program.  If not, see //<http://www.gnu.org/licenses/>.
 'use strict';
 
-var distanceCalculator = function(entries) {
+var distanceCalculator = function(entries, target) {
   // First, create a dict of candidates, where the key is the comparison form
   // and the value is the entry itself.
   var candidates = {};
   var candidateKeys = [];
   for (var i = 0; i < entries.length; i++) {
     var entry = entries[i];
-    if ('compare_form' in entry) {
-      var compareForm = entry['compare_form'].toLowerCase();
+    if (typeof target != 'undefined' && target in entry) {
+      var compareForm = entry[target].toLowerCase();
     } else {
       var compareForm = entry['word'].toLowerCase();
     }
-    // If target entry is a phrase
-    if (compareForm.indexOf(' ') >= 0) {
-      var compare_form_array = compareForm.split(' ');
-      for (var k = 0; k < compare_form_array.length; k++) {
-        if (!(compare_form_array[k] in candidates)) {
-          candidates[compare_form_array[k]] = [];
-          candidateKeys.push(String(compare_form_array[k]));
-        }
-        if (!(entry in candidates)) {
-          candidates[compare_form_array[k]].push(entry);
-        }
-      }
-      // If target entry is a word
-    } else {
-      if (!(compareForm in candidates)) {
-        candidates[compareForm] = [];
-        candidateKeys.push(String(compareForm));
-      }
-      candidates[compareForm].push(entry);
-    }
-  }
-  // Then build a Levenshtein Automaton from the keys
-  var builder = new levenshtein.Builder()
-    .dictionary(candidateKeys, false)
-    .algorithm('transposition')
-    .sort_candidates(true)
-    .include_distance(true)
-    .maximum_candidates(10);
-  var transducer = builder.transducer();
-
-  // Return the appropriate search function
-  return function(query) {
-    var results = [];
-    var distanceFormPairs = transducer.transduce(
-      query,
-      Math.floor(query.length / 3.0)
-    );
-    for (var i = 0; i < distanceFormPairs.length; i++) {
-      var distance = distanceFormPairs[i][1];
-      var form = distanceFormPairs[i][0];
-      var resultingEntries = candidates[form];
-      for (var j = 0; j < resultingEntries.length; j++) {
-        resultingEntries[j]['distance'] = distance;
-        results.push([distance, resultingEntries[j]]);
-      }
-    }
-    return results;
-  };
-};
-
-var distanceCalculatorWord = function(entries) {
-  // First, create a dict of candidates, where the key is the comparison form
-  // and the value is the entry itself.
-  var candidates = {};
-  var candidateKeys = [];
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i];
-    var compareForm = entry['word'].toLowerCase();
     // If target entry is a phrase
     if (compareForm.indexOf(' ') >= 0) {
       var compare_form_array = compareForm.split(' ');

--- a/projects/mtd/src/assets/js/mtd-ui.min.js
+++ b/projects/mtd/src/assets/js/mtd-ui.min.js
@@ -1053,66 +1053,16 @@ mtd.convertQuery = function(str) {
   m.levenshtein.Builder = p;
 }.call(this));
 ('use strict');
-var distanceCalculator = function(entries) {
+var distanceCalculator = function(entries, target) {
   var candidates = {};
   var candidateKeys = [];
   for (var i = 0; i < entries.length; i++) {
     var entry = entries[i];
-    if ('compare_form' in entry) {
-      var compareForm = entry['compare_form'].toLowerCase();
+    if (typeof target != 'undefined' && target in entry) {
+      var compareForm = entry[target].toLowerCase();
     } else {
       var compareForm = entry['word'].toLowerCase();
     }
-    if (compareForm.indexOf(' ') >= 0) {
-      var compare_form_array = compareForm.split(' ');
-      for (var k = 0; k < compare_form_array.length; k++) {
-        if (!(compare_form_array[k] in candidates)) {
-          candidates[compare_form_array[k]] = [];
-          candidateKeys.push(String(compare_form_array[k]));
-        }
-        if (!(entry in candidates)) {
-          candidates[compare_form_array[k]].push(entry);
-        }
-      }
-    } else {
-      if (!(compareForm in candidates)) {
-        candidates[compareForm] = [];
-        candidateKeys.push(String(compareForm));
-      }
-      candidates[compareForm].push(entry);
-    }
-  }
-  var builder = new levenshtein.Builder()
-    .dictionary(candidateKeys, false)
-    .algorithm('transposition')
-    .sort_candidates(true)
-    .include_distance(true)
-    .maximum_candidates(10);
-  var transducer = builder.transducer();
-  return function(query) {
-    var results = [];
-    var distanceFormPairs = transducer.transduce(
-      query,
-      Math.floor(query.length / 3)
-    );
-    for (var i = 0; i < distanceFormPairs.length; i++) {
-      var distance = distanceFormPairs[i][1];
-      var form = distanceFormPairs[i][0];
-      var resultingEntries = candidates[form];
-      for (var j = 0; j < resultingEntries.length; j++) {
-        resultingEntries[j]['distance'] = distance;
-        results.push([distance, resultingEntries[j]]);
-      }
-    }
-    return results;
-  };
-};
-var distanceCalculatorWord = function(entries) {
-  var candidates = {};
-  var candidateKeys = [];
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i];
-    var compareForm = entry['word'].toLowerCase();
     if (compareForm.indexOf(' ') >= 0) {
       var compare_form_array = compareForm.split(' ');
       for (var k = 0; k < compare_form_array.length; k++) {
@@ -1212,9 +1162,9 @@ function getAllAudioEntries() {
 var l1SearchAlg = null;
 var l1SearchAlgWord = null;
 function searchL1(query_value) {
-  if (l1SearchAlg === null || l1SearchAlgWord) {
-    l1SearchAlg = distanceCalculator(getAllEntries());
-    l1SearchAlgWord = distanceCalculatorWord(getAllEntries());
+  if (l1SearchAlg === null || l1SearchAlgWord === null) {
+    l1SearchAlg = distanceCalculator(getAllEntries(), 'compare_form');
+    l1SearchAlgWord = distanceCalculator(getAllEntries(), 'word');
   }
   query_value = query_value.toLowerCase();
   if (query_value.indexOf(' ') >= 0) {


### PR DESCRIPTION
Because the code in the search component doesn't copy the results objects before modifying their weights, exact search results in L1 were showing up as "partial results", because, well, an exact match *is also a partial match* and so the same object was getting downweighted when partial results were processed.

Exact search results in L2 were doing something else, because the fuzzy match scores were not actually being used as intended - one part of the code was downweighting the `distance` attribute while the other part was looking at the first item in the result array, and only one of these was being modified.  Now it always uses the `distance` attribute - that first item is still there but probably it shouldn't be.